### PR TITLE
revert readme to template readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# This repo is for the 2026 FIRST Rebuilt Season.
-It was forked from the [arc-template](https://github.com/athenian-robotics/arc-template) repo
+# This is a template to use for Team 852 ARC Robotics
+It was created over the 2025 and 2026 seasons with help from [@Non-Binary-Programmer](https://github.com/Non-Binary-Programmer), [@27mrandazzo](https://github.com/27mrandazzo), [@28dchen](https://github.com/28dchen), [@JS7077](https://github.com/JS7077), and [@pi-was-taken](https://github.com/pi-was-taken).
+This template includes **swerve drive** and **limelight** code that can be used across multiple seasons.


### PR DESCRIPTION
Updated the README to reflect the purpose of the template and contributors. It got overwritten by the 2026 rebuilt one and got overlooked